### PR TITLE
[deleted]

### DIFF
--- a/web/src/assets/styles.js
+++ b/web/src/assets/styles.js
@@ -181,7 +181,7 @@ export const Result = styled.div`
 
         span {
           display: block;
-          min-width: 120px;
+          min-width: 220px;
           font-size: 1rem;
         }
       }

--- a/web/src/components/subcomponents/searchResult/Detail.js
+++ b/web/src/components/subcomponents/searchResult/Detail.js
@@ -8,16 +8,36 @@ class Detail extends Component {
         {res.hospital && (
           <div className="details__col">
             <p>
-              <span>Beds:</span> <b>{res.bedCount}</b>
+              <span>Total Beds:</span>{" "}
+              <b>{res.total_beds_allocated_to_covid}</b>
             </p>
+            {res.total_beds_with_oxygen !== 0 && (
+              <p>
+                <span>Beds With Oxygen:</span>{" "}
+                <b>{res.total_beds_with_oxygen}</b>
+              </p>
+            )}
+            {res.total_beds_without_oxygen !== 0 && (
+              <p>
+                <span>Beds Without Oxygen:</span>{" "}
+                <b>{res.total_beds_without_oxygen}</b>
+              </p>
+            )}
+            {res.total_icu_beds_with_ventilator !== 0 && (
+              <p>
+                <span>ICU Beds With Ventilator:</span>{" "}
+                <b>{res.total_icu_beds_with_ventilator}</b>
+              </p>
+            )}
+            {res.total_icu_beds_without_ventilator !== 0 && (
+              <p>
+                <span>ICU Beds Without Ventilator:</span>{" "}
+                <b>{res.total_icu_beds_without_ventilator}</b>
+              </p>
+            )}
             <p>
               <span>ICUs:</span> <b>{res.icuCount}</b>
             </p>
-            {res.oxygenBeds && (
-              <p>
-                <span>Oxygen Beds:</span> <b>{res.oxygenBeds}</b>
-              </p>
-            )}
             <p>
               <span>Ventilator:</span> <b>{res.ventilatorCount}</b>
             </p>


### PR DESCRIPTION
The bedCount field does not match the bed counts that are available in the field total_beds_allocated_to_covid.

The field total_beds_allocated_to_covid seems to give a better value because this value matches with the sum of the fields total_beds_with_oxygen, total_beds_without_oxygen, total_icu_beds_with_ventilator, total_icu_beds_without_ventilator

Before Fix
![total_beds_allocated_to_covid-AND-bedcount-mismatch](https://user-images.githubusercontent.com/39409007/119374983-8e2a2e00-bcba-11eb-89c2-cc20ecb590e7.png)

After Fix
![fix_bed_display_count](https://user-images.githubusercontent.com/39409007/119375002-94200f00-bcba-11eb-931a-d5cef2a3b448.png)
